### PR TITLE
Added sort feature for posts endpoint

### DIFF
--- a/controllers/post.controller.js
+++ b/controllers/post.controller.js
@@ -11,8 +11,14 @@ const postController = {
         //create base query
         let query = {}
 
-        let limit = parseInt(req.query.limit) || 100
-        let skip =  parseInt(req.query.offset) || 0
+        let limit = parseInt(req.query.limit)  || 100
+        let skip  = parseInt(req.query.offset) || 0
+        let sort  = req.query.offset;
+        let sortValue = { createdAt: 'desc' }
+        if (sort) {
+            let sortOrder = sort.startsWith("-") ? 'desc' : 'asc';
+            sortValue = { [sort]: sortOrder };
+        }
 
         //if firstName filter appears in query parameters then modify the query to do a fuzzy search
         if(req.query.username){
@@ -25,7 +31,7 @@ const postController = {
             //use our model to find users that match a query.
             //{} is the current query which really mean find all the users
             //we use await here since this is an async process and we want the code to wait for this to finish before moving on to the next line of code
-            let allPosts = await Post.find(query, {__v: 0}).populate("likes", {__v: 0}).limit(limit).skip(skip)
+            let allPosts = await Post.find(query, {__v: 0}).populate("likes", {__v: 0}).skip(skip).limit(limit).sort(sortValue);
             
             //return all the users that we found in JSON format
             res.json(allPosts)

--- a/specification.yaml
+++ b/specification.yaml
@@ -164,6 +164,13 @@ components:
         format: int32
         minimum: 0
         default: 0
+    sortParam:
+      name: sort
+      in: query
+      description: Field to sort by ascendingly by default, and decendingly if `-` is prepended (defaults to `-createdBy`)
+      required: false
+      schema:
+        type: string
   headers:
     WWW-Authenticate:
       description: Includes the URI location to receive a bearer token
@@ -433,6 +440,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/limitParam"
         - $ref: "#/components/parameters/offsetParam"
+        - $ref: "#/components/parameters/sortParam"
         - name: username
           in: query
           description: Get posts created by this username


### PR DESCRIPTION
This pull request adds the ability to sort posts by any field in either ascending or descending order.

Examples:
- `/api/posts?sort=createdBy` - Sorts posts by their createdBy property in ascending order
- `/api/posts?sort=-createdBy` - Sorts posts by their createdBy property in descending order