### PR TITLE
Add smooth setup option for running the MongoDB instance locally.…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,30 +2,26 @@
 
 This API represents the basic fetures of a twitter(ish) site. The API supports Users, Authentication, Posts, and Likes. Users should be able to register, sign in, create posts, delete posts, like posts, and update their profile information.
 
-## Basic setup for local development
-The API requires uses Mongoose and a MongoDB database. To work with the API locally you will need to create the DB locally, create a local .env file with your database URL, and setup your .env file.
+## Setup
+- Clone this repository to your machine and `cd` into the directory.
+- In your terminal, **run `npm install`**.
 
-### Create the Database
- - Make sure MongoDB is installed on your machine. 
+### Two ways to run this API server
+#### Local MongoDB database
+- If you want to run this API server with a **locally-installed database**, make sure MongoDB is installed on your machine and running as a service. To use this database, simply run `npm run local` or `npm run local-watch`.
 
-### Set up the code
-- For then clone this repository
-- Change directories to the cloned repository `cd microblogLite`
-- create your `.env` file by copying the example provided `cp .env.example .env`
-- edit the `.env` file to include something similar to the following example:
+#### Cloud MongoDB database
+- If you want to run this server with a **cloud database**, you will need to create a `.env` file by copying the `.env.example` file provided (`cp .env.example .env`) and edit it to include the correct connection details. Finally, run `npm start` or `npm watch`. A valid `.env` might look like this:
   ```
-  DATABASE_URL="mongodb://127.0.0.1:227017/DB_NAME_HERE"
+  DATABASE_URL="mongodb+srv://USERNAME:PASSWORD@SUBDOMAINS.mongodb.net/microblogLite?retryWrites=true&w=majority"
   JWT_SECRET="whateveryouwant"
   ```
 
-### Install dependencies
-- From the command line, type `npm install`
-- From the command line, type `npm start` or `npm run watch` if you want to leverage `nodemon`.
-- Test the API by making a accessing `http://localhost:5000` in a broswer
 
-> **NOTE:** visiting `http://localhost:5000` will take you to a swagger/openapi documentation that describes and allows you test all the endpoints.
+### Testing that this API server is running
+Visit [http://localhost:5000/](http://localhost:5000/) in your browser. You should see the MicroblogLite API documentation page.
 
-### HTML sanitization
+## Notes on HTML sanitization
 - Any HTML in the `username` and `fullName` fields will be removed automatically.
 - Any HTML in the Post `text` and User `bio` fields will be sanitized. Some tags and attributes will be removed.
 - Tags and attributes allowed are partially listed [here](https://www.npmjs.com/package/sanitize-html#default-options) under the `allowedTags` and `allowedAttributes` objects listed there. 
@@ -48,12 +44,12 @@ The API requires uses Mongoose and a MongoDB database. To work with the API loca
     - translate
 - Sanitizers are defined in `/services/sanitizers.js` and implemented in the controllers for the POST and PUT endpoints for Users and Posts.
 
-### FOR MAINTAINERS
+## FOR MAINTAINERS
 
-#### Prism
+### Prism
 
 [Prism](https://github.com/stoplightio/prism?tab=readme-ov-file#validation-proxy) helps us keep the OpenAPI/Swagger specification ([/specification.yaml](./specification.yaml)) in sync with the implementation. First ensure the Express server is running (`npm start`). Then run `npx prism proxy ./specification.yaml http://localhost:5000 --errors` or `npm run prism` to start the API validator proxy. Point your Postman client or front-end to the Prism server (likely http://127.0.0.1:4010). API requests sent through the Prism proxy will be validated against our OpenAPI spec before being passed onto the actual Express server.
 
-#### Passport versions
+### Passport versions
 
 As of October 2024, the latest versions of Passport (v0.6.0 and v0.7.0) introduced a breaking change which ignores the `session: false` option, causing our current sessionless JWT implementation to error out, complaining that we aren't running session middleware. So right now, we're keeping Passport to v0.5.3. Hopefully, a future version will restore the sessionless functionality. Otherwise, we'll have to try to hold on v0.5.3 for as long as possible, replace Passport, or refactor our auth solution to use sessions to appease Passport.

--- a/app.js
+++ b/app.js
@@ -1,4 +1,11 @@
-require('dotenv-safe').config();
+const dotenv = require('dotenv-safe');
+
+if (process.env.NODE_ENV !== 'development') {
+    dotenv.config({
+        allowEmptyValues: true,
+        example: '.env.example',
+    });
+};
 
 const express = require('express');
 const cookieParser = require('cookie-parser');

--- a/bin/www
+++ b/bin/www
@@ -25,11 +25,13 @@ const server = http.createServer(app);
 const mongoose = require('mongoose');
 mongoose.set('strictQuery', true);
 
+console.info('⌛ Waiting for the database to connect...')
 //Use mongoose to connect to MongoDB. Display success or failure message depending on connection status
 //If a connection to Mongo is successful, the server will start listening.
-mongoose.connect(process.env.DATABASE_URL || 'mongodb://127.0.0.1:27017/myApplication')
-    .then(() => {
-        console.log('we have connected to mongo')
+mongoose.connect(process.env.DATABASE_URL || 'mongodb://127.0.0.1:27017/microblogLite')
+    .then((connection) => {
+        const url = new URL(connection.connection.client.s.url)
+        console.info('✅ Connected to database at', url.host)
 
         /**
          * Listen on provided port, on all network interfaces.
@@ -39,7 +41,7 @@ mongoose.connect(process.env.DATABASE_URL || 'mongodb://127.0.0.1:27017/myApplic
         server.on('error', onError);
         server.on('listening', onListening);
     }).catch(() => {
-        console.log('could not connect to mongo')
+        console.log('❌ Could not connect to the database!')
     });
 
 
@@ -100,5 +102,6 @@ function onListening() {
     const bind = typeof addr === 'string'
         ? 'pipe ' + addr
         : 'port ' + addr.port;
+    console.log('👂 Server listening on localhost', bind);
     debug('Listening on ' + bind);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
       },
       "devDependencies": {
         "@stoplight/prism-cli": "^5.10.0",
+        "cross-env": "^7.0.3",
         "nodemon": "^3.1.7"
       },
       "engines": {
@@ -1220,6 +1221,25 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/cross-fetch": {
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
@@ -1228,6 +1248,21 @@
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.6.12"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/crypt": {
@@ -2264,6 +2299,13 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/isomorphic-fetch": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
@@ -3206,6 +3248,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
@@ -3744,6 +3796,29 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
@@ -4238,6 +4313,22 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/wide-align": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   "scripts": {
     "start": "node ./bin/www",
     "watch": "nodemon",
+    "local": "cross-env NODE_ENV=development JWT_SECRET=foobar node ./bin/www",
+    "watch-local": "cross-env NODE_ENV=development JWT_SECRET=foobar nodemon",
     "prism": "npx prism proxy ./specification.yaml http://localhost:5000 --errors"
   },
   "dependencies": {
@@ -30,6 +32,7 @@
   },
   "devDependencies": {
     "@stoplight/prism-cli": "^5.10.0",
+    "cross-env": "^7.0.3",
     "nodemon": "^3.1.7"
   }
 }


### PR DESCRIPTION
No additional configuration required:
1. Install MongoDB
2. Run it as a service
3. `npm install`
4. `npm run local` or `npm run local-watch`

`.env` still works with `npm start` and `npm watch` if you want to use a cloud DB.

Documentation adjusted as necessary.